### PR TITLE
Minor fixes for submap painter. Disable proto system wide

### DIFF
--- a/cartographer/io/submap_painter.cc
+++ b/cartographer/io/submap_painter.cc
@@ -206,7 +206,10 @@ UniqueCairoSurfacePtr DrawTexture(const std::vector<char>& intensity,
     // We use the red channel to track intensity information. The green
     // channel we use to track if a cell was ever observed.
     const uint8_t intensity_value = intensity.at(i);
-    const uint8_t alpha_value = alpha.at(i);
+    // Make darker only the cells which are actually occupied,
+    // and not grayish-looking cells
+    const uint8_t alpha_value =
+        (intensity_value == 0 && alpha.at(i) > 0) : 255 ? alpha.at(i);
     const uint8_t observed =
         (intensity_value == 0 && alpha_value == 0) ? 0 : 255;
     cairo_data->push_back((alpha_value << 24) | (intensity_value << 16) |

--- a/cartographer/io/submap_painter.cc
+++ b/cartographer/io/submap_painter.cc
@@ -209,7 +209,7 @@ UniqueCairoSurfacePtr DrawTexture(const std::vector<char>& intensity,
     // Make darker only the cells which are actually occupied,
     // and not grayish-looking cells
     const uint8_t alpha_value =
-        (intensity_value == 0 && alpha.at(i) > 0) : 255 ? alpha.at(i);
+        (intensity_value == 0 && alpha.at(i) > 0) ? 255 : alpha.at(i);
     const uint8_t observed =
         (intensity_value == 0 && alpha_value == 0) ? 0 : 255;
     cairo_data->push_back((alpha_value << 24) | (intensity_value << 16) |

--- a/scripts/install_proto3.sh
+++ b/scripts/install_proto3.sh
@@ -31,4 +31,7 @@ cmake -G Ninja \
   -Dprotobuf_BUILD_TESTS=OFF \
   ../cmake
 ninja
-sudo ninja install
+
+if [ "$1" != "--local" ]; then
+  sudo ninja install
+fi


### PR DESCRIPTION
Disable system wide protobuf install.
Makes the occupied cells darker.